### PR TITLE
Improve UK tenders scraper with default keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# scraper
+# UK Open Tenders Scraper
+
+This repository contains a simple Python script for scraping open tenders from the UK Contracts Finder website.
+
+## Requirements
+
+- Python 3.8+
+- [`requests`](https://pypi.org/project/requests/)
+- [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/)
+
+Install the dependencies using `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the scraper with one or more service keywords. When no keywords are
+provided, the script searches for tenders related to **software testing**,
+**digital health**, **EPR benefit realisation**, and **CRM development**.
+
+```bash
+python scrape_open_tenders.py --pages 2
+```
+
+You can provide your own keywords, for example:
+
+```bash
+python scrape_open_tenders.py "cyber security" "data analytics"
+```
+
+The script prints the title, closing date, and URL for each tender found for
+each keyword.
+
+## Notes
+
+- The script queries the publicly available search interface at `https://www.contractsfinder.service.gov.uk`. Be mindful of the website's terms of use and do not overwhelm the service with excessive requests.
+- Pagination is handled via the `--pages` argument. Increase this value to fetch additional pages of results.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scrape_open_tenders.py
+++ b/scrape_open_tenders.py
@@ -1,0 +1,80 @@
+import requests
+from bs4 import BeautifulSoup
+
+
+def scrape_open_tenders(service_keyword: str, pages: int = 1):
+    """Scrape open tenders from Contracts Finder for a given service keyword.
+
+    Args:
+        service_keyword: Keyword describing the service to search for.
+        pages: Number of search result pages to retrieve.
+
+    Returns:
+        A list of dictionaries containing tender details.
+    """
+    base_url = "https://www.contractsfinder.service.gov.uk/Search/Results"
+    tenders = []
+    for page in range(1, pages + 1):
+        params = {
+            "page": page,
+            "status": "Open",
+            "keyword": service_keyword,
+        }
+        response = requests.get(base_url, params=params, timeout=10)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        for notice in soup.select(".search-result"):  # each result block
+            title_elem = notice.select_one("h2 a")
+            closing_elem = notice.select_one("span.closing-date")
+            if not title_elem:
+                continue
+            tender = {
+                "title": title_elem.get_text(strip=True),
+                "url": "https://www.contractsfinder.service.gov.uk" + title_elem["href"],
+                "closing_date": closing_elem.get_text(strip=True) if closing_elem else None,
+            }
+            tenders.append(tender)
+    return tenders
+
+
+DEFAULT_KEYWORDS = [
+    "software testing",
+    "digital health",
+    "epr benefit realisation",
+    "crm development",
+]
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Scrape open UK tenders for one or more service keywords"
+    )
+    parser.add_argument(
+        "keywords",
+        nargs="*",
+        default=DEFAULT_KEYWORDS,
+        help=(
+            "Service keywords to search for. If omitted, a set of default "
+            "keywords is used."
+        ),
+    )
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=1,
+        help="Number of result pages to scrape for each keyword",
+    )
+    args = parser.parse_args()
+
+    for keyword in args.keywords:
+        print(f"### Results for: {keyword}\n")
+        results = scrape_open_tenders(keyword, args.pages)
+        for tender in results:
+            print(f"{tender['title']} - {tender['closing_date']}")
+            print(f"{tender['url']}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow multiple keywords and define default focus areas
- update README with new usage instructions

## Testing
- `python -m py_compile scrape_open_tenders.py`
- `python scrape_open_tenders.py --pages 1` *(fails: ModuleNotFoundError for requests)*

------
https://chatgpt.com/codex/tasks/task_e_6855d5da9d74832fa6b95d7769d6569c